### PR TITLE
We don't actually care about the second capture group.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ class Jade(Linter):
     multiline = True
     regex = r'''(?xi)
         Error: .+?:(?P<line>\d+).*\r?\n
-        (.*\|.*\n)+
+        (?:.*\|.*\n)+
         .*\n
         (?P<message>.*)
     '''


### PR DESCRIPTION
[Here](https://regex101.com/r/pU0hF6/5) for reference is how I tested this. We don't actually care about that part of the error output(the second capture group)...it's just on the way.  I switched to a non-capturing group.

An alternate regex you could use, which accomplishes the same end result: 

```
Error: (\S+):(\d+).*\r?\n(?:.*\|.*\n)+.*\n(.*)
```

This gives: 
- File Name
- Line number(s)
- and the error message(s).

For the sake of this PR, I just made the second capture group a non-capturing group, we don't actually care about the value. Also, thank you for this :heart:  -- I am contributing back an improvement! 
